### PR TITLE
Allow copying discussion url on `ShareModal`

### DIFF
--- a/js/src/admin/index.tsx
+++ b/js/src/admin/index.tsx
@@ -1,33 +1,38 @@
 import app from 'flarum/admin/app';
 
 const networks = [
-  ['facebook', 'twitter', 'linkedin', 'reddit'],
-  ['whatsapp', 'telegram'],
-  ['vkontakte', 'odnoklassniki', 'my_mail'],
-  ['qq', 'qzone'],
-  ['native'],
+  'facebook',
+  'twitter',
+  'linkedin',
+  'reddit',
+  'whatsapp',
+  'telegram',
+  'vkontakte',
+  'odnoklassniki',
+  'my_mail',
+  'qq',
+  'qzone',
+  'native',
 ];
 
 app.initializers.add('fof/share-social', () => {
-  let set = app.extensionData.for('fof-share-social');
+  const set = app.extensionData.for('fof-share-social');
 
-  set.registerSetting({
-    label: app.translator.trans('fof-share-social.admin.settings.canonical-urls'),
-    setting: 'fof-share-social.canonical-urls',
-    type: 'boolean',
-  });
+  set
+    .registerSetting({
+      label: app.translator.trans('fof-share-social.admin.settings.canonical-urls'),
+      setting: 'fof-share-social.canonical-urls',
+      type: 'boolean',
+    })
+    .registerSetting(function () {
+      return <hr />;
+    });
 
-  set.registerSetting(function () {
-    return <hr />;
-  });
-
-  networks.forEach((networks) =>
-    networks.forEach((network) =>
-      set.registerSetting({
-        label: app.translator.trans(`fof-share-social.lib.networks.${network}`),
-        setting: `fof-share-social.networks.${network}`,
-        type: 'boolean',
-      })
-    )
+  networks.forEach((network) =>
+    set.registerSetting({
+      label: app.translator.trans(`fof-share-social.lib.networks.${network}`),
+      setting: `fof-share-social.networks.${network}`,
+      type: 'boolean',
+    })
   );
 });

--- a/js/src/forum/components/ShareModal.js
+++ b/js/src/forum/components/ShareModal.js
@@ -54,12 +54,12 @@ export default class ShareModal extends Modal {
       <div className="Modal-body">
         <div className="Form Form--centered">
           <div className="Form-group ShareUrl">
-            <input
-              className="FormControl"
-              type="text"
-              value={this.discussion.shareUrl()}
-            />
-            <Button className={"Button Button--primary Button--copy"} onclick={this.copy.bind(this)}>
+            <input className="FormControl" type="text" value={this.discussion.shareUrl()} />
+            <Button
+              className={'Button Button--primary'}
+              aria-label={app.translator.trans('fof-share-social.forum.modal.copy_button')}
+              onclick={this.copy.bind(this)}
+            >
               {icon('fas fa-copy fa-check')}
             </Button>
           </div>
@@ -111,18 +111,18 @@ export default class ShareModal extends Modal {
   }
 
   copy() {
-    const copyText = document.querySelector(".ShareUrl input");
+    const copyText = document.querySelector('.ShareUrl input');
     copyText.select();
     copyText.setSelectionRange(0, 99999);
-    document.execCommand("copy");
+    document.execCommand('copy');
     this.toggleCopyIcon();
   }
 
   toggleCopyIcon() {
-    const copyButton = document.querySelector(".Button--copy i");
-    copyButton.classList.toggle("fa-copy");
+    const copyButton = document.querySelector('.ShareUrl button i');
+    copyButton.classList.toggle('fa-copy');
     setTimeout(() => {
-      copyButton.classList.toggle("fa-copy");
+      copyButton.classList.toggle('fa-copy');
     }, 3000);
   }
 }

--- a/js/src/forum/components/ShareModal.js
+++ b/js/src/forum/components/ShareModal.js
@@ -1,6 +1,7 @@
 import app from 'flarum/forum/app';
 import Modal from 'flarum/common/components/Modal';
 import Button from 'flarum/common/components/Button';
+import icon from 'flarum/common/helpers/icon';
 import { truncate, getPlainContent } from 'flarum/common/utils/string';
 
 import pupa from 'pupa';
@@ -52,6 +53,16 @@ export default class ShareModal extends Modal {
     return (
       <div className="Modal-body">
         <div className="Form Form--centered">
+          <div className="Form-group ShareUrl">
+            <input
+              className="FormControl"
+              type="text"
+              value={this.discussion.shareUrl()}
+            />
+            <Button className={"Button Button--primary Button--copy"} onclick={this.copy.bind(this)}>
+              {icon('fas fa-copy fa-check')}
+            </Button>
+          </div>
           <div className="Form-group">
             {this.networks
               .filter((name) => name !== 'native' || navigator.canShare?.(navigatorData(this.data())))
@@ -97,5 +108,21 @@ export default class ShareModal extends Modal {
     const description = (this.discussion.firstPost() && truncate(getPlainContent(this.discussion.firstPost()?.contentHtml()), 150, 0)) || '';
 
     return { url, title, description };
+  }
+
+  copy() {
+    const copyText = document.querySelector(".ShareUrl input");
+    copyText.select();
+    copyText.setSelectionRange(0, 99999);
+    document.execCommand("copy");
+    this.toggleCopyIcon();
+  }
+
+  toggleCopyIcon() {
+    const copyButton = document.querySelector(".Button--copy i");
+    copyButton.classList.toggle("fa-copy");
+    setTimeout(() => {
+      copyButton.classList.toggle("fa-copy");
+    }, 3000);
   }
 }

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -13,23 +13,23 @@ app.initializers.add('fof/share-social', () => {
   extend(DiscussionPage.prototype, 'sidebarItems', function (items) {
     const networks = app.forum.attribute('fof-share-social.networks');
 
-    if (networks.length) {
-      items.add(
-        'share-social',
-        <Button
-          class="Button Button-icon Button--share"
-          icon="fas fa-share-alt"
-          onclick={() =>
-            app.modal.show(ShareModal, {
-              networks,
-              discussion: this.discussion,
-            })
-          }
-        >
-          {app.translator.trans('fof-share-social.forum.discussion.share_button')}
-        </Button>,
-        -1
-      );
-    }
+    if (!networks.length) return;
+
+    items.add(
+      'share-social',
+      <Button
+        class="Button Button-icon Button--share"
+        icon="fas fa-share-alt"
+        onclick={() =>
+          app.modal.show(ShareModal, {
+            networks,
+            discussion: this.discussion,
+          })
+        }
+      >
+        {app.translator.trans('fof-share-social.forum.discussion.share_button')}
+      </Button>,
+      -1
+    );
   });
 });

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -8,12 +8,9 @@
   .ShareUrl {
     display: flex;
     gap: 5px;
-
-    .Button--copy {
-    }
   }
 
-  .Button:not(.Button--copy) {
+  .Button:not(.ShareUrl .Button) {
     width: 100%;
     border-radius: @border-radius;
     margin-top: 10px !important;

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -5,8 +5,15 @@
 }
 
 .FofShareSocialModal .Modal-body {
+  .ShareUrl {
+    display: flex;
+    gap: 5px;
 
-  .Button {
+    .Button--copy {
+    }
+  }
+
+  .Button:not(.Button--copy) {
     width: 100%;
     border-radius: @border-radius;
     margin-top: 10px !important;
@@ -43,7 +50,7 @@
   .Share--qq {
     .Button--color(#fff, #12B8F6);
   }
-  
+
   .Share--qzone {
     .Button--color(#fff, #FFBB30);
   }
@@ -55,7 +62,7 @@
   .Share--telegram {
     .Button--color(#fff, #0088cc);
   }
-  
+
   .fa-lg {
     font-size: 1.33333333em;
     line-height: 0.75em;

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -8,6 +8,7 @@ fof-share-social:
 
     modal:
       title: Share
+      copy_button: Copy
 
   lib:
     networks:


### PR DESCRIPTION
This PR has changes:
- Reformat admin code
- Add feature that allows users copy the discussion url directly on ShareModal

Before click to copy button
![image](https://user-images.githubusercontent.com/56961917/187958926-d13aa268-07ab-47b7-97b3-87d6c638c36f.png)

After click to copy button
![image](https://user-images.githubusercontent.com/56961917/187959004-bf2b2ed4-cdbf-4bb7-9804-9b848a47c719.png)

