### PR TITLE
Add a 'default' network option that changes modal into split dropdown

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -28,7 +28,8 @@ return [
 
     (new Extend\Settings())
         ->default('fof-share-social.plain-copy', true)
-        ->serializeToForum('fof-share-social.plain-copy', 'fof-share-social.plain-copy'),
+        ->serializeToForum('fof-share-social.plain-copy', 'fof-share-social.plain-copy')
+        ->serializeToForum('fof-share-social.default', 'fof-share-social.default-option'),
 
     (new Extend\ApiSerializer(ForumSerializer::class))
         ->attributes(ForumAttributes::class),

--- a/js/src/admin/index.tsx
+++ b/js/src/admin/index.tsx
@@ -1,4 +1,5 @@
 import app from 'flarum/admin/app';
+import type { SelectSettingComponentOptions } from 'flarum/admin/components/AdminPage';
 
 const networks = [
   'facebook',
@@ -28,6 +29,19 @@ app.initializers.add('fof/share-social', () => {
       label: app.translator.trans('fof-share-social.admin.settings.plain-copy'),
       setting: 'fof-share-social.plain-copy',
       type: 'boolean',
+    })
+    .registerSetting({
+      label: app.translator.trans('fof-share-social.admin.settings.default-option'),
+      help: app.translator.trans('fof-share-social.admin.settings.default-option-help'),
+      setting: 'fof-share-social.default-option',
+      type: 'select',
+      options: networks.reduce(
+        (o, network) => {
+          o[network] = app.translator.trans(`fof-share-social.lib.networks.${network}`);
+          return o;
+        },
+        { '': '' } as SelectSettingComponentOptions['options']
+      ),
     })
     .registerSetting(function () {
       return <hr />;

--- a/js/src/forum/components/ShareModal.js
+++ b/js/src/forum/components/ShareModal.js
@@ -2,37 +2,11 @@ import app from 'flarum/forum/app';
 import Modal from 'flarum/common/components/Modal';
 import Button from 'flarum/common/components/Button';
 import icon from 'flarum/common/helpers/icon';
-import { truncate, getPlainContent } from 'flarum/common/utils/string';
 
 import pupa from 'pupa';
 import ItemList from 'flarum/common/utils/ItemList';
-
-const navigatorData = ({ title, description, url }) => ({ title, text: description, url });
-
-const share = {
-  facebook: '//facebook.com/sharer/sharer.php?u={url}',
-  twitter: '//twitter.com/share?url={url}&text={title}',
-  linkedin: '//linkedin.com/shareArticle?mini=true&url={url}&title={title}&summary={description}',
-  reddit: '//www.reddit.com/submit?url={url}&title={title}',
-  whatsapp: '//api.whatsapp.com/send/?phone&text={title}%20{url}',
-  telegram: '//telegram.me/share/url?url={url}&text={title}',
-
-  vkontakte: '//vk.com/share.php?url={url}&title={title}&description={description}',
-  odnoklassniki: '//connect.ok.ru/offer?url={url}',
-  my_mail: '//connect.mail.ru/share?url={url}&title={title}&description={description}',
-  qq: '//connect.qq.com/widget/shareqq/iframe_index.html?url={url}&title={title}',
-  qzone: '//sns.qzone.qq.com/cgi-bin/qzshare/cgi_qzshare_onekey?url={url}&summary={description}&title={title}',
-
-  native: (data) => navigator.share(navigatorData(data)),
-};
-
-const shareIcons = {
-  vkontakte: 'fab fa-vk',
-  my_mail: 'fas fa-at',
-  qq: 'fab fa-qq',
-  qzone: 'fas fa-star',
-  native: 'fas fa-share-square',
-};
+import { canNativeShare } from '../util/share';
+import { getNetworkButton } from '../util/networks';
 
 export default class ShareModal extends Modal {
   oninit(vdom) {
@@ -66,19 +40,8 @@ export default class ShareModal extends Modal {
 
     {
       this.networks
-        .filter((name) => name !== 'native' || navigator.canShare?.(navigatorData(this.data())))
-        .map((network) =>
-          items.add(
-            `network-${network}`,
-            <Button
-              className={`Button Button--rounded Button--block Share--${network}`}
-              icon={`${shareIcons[network] || `fab fa-${network}`} fa-lg fa-fw`}
-              onclick={this.onclick.bind(this, network)}
-            >
-              {app.translator.trans(`fof-share-social.lib.networks.${network}`)}
-            </Button>
-          )
-        );
+        .filter((name) => name !== 'native' || canNativeShare(this.discussion))
+        .map((network) => items.add(`network-${network}`, getNetworkButton({ network, discussion: this.discussion, isRounded: true })));
     }
 
     if (plainCopy) {
@@ -101,32 +64,7 @@ export default class ShareModal extends Modal {
   }
 
   onclick(network) {
-    const data = this.data();
-    const action = share[network];
-
-    if (typeof action === 'function') {
-      return action(data);
-    }
-
-    const width = 1000;
-    const height = 500;
-    const top = $(window).height() / 2 - height / 2;
-    const left = $(window).width() / 2 - width / 2;
-    const windowParams = `width=${width}, height= ${height}, top=${top}, left=${left}, status=no, scrollbars=no, resizable=no`;
-
-    for (const dataKey in data) {
-      data[dataKey] = encodeURIComponent(data[dataKey]);
-    }
-
-    window.open(pupa(action, data), app.title, windowParams);
-  }
-
-  data() {
-    const url = this.discussion.shareUrl();
-    const title = app.title;
-    const description = (this.discussion.firstPost() && truncate(getPlainContent(this.discussion.firstPost()?.contentHtml()), 150, 0)) || '';
-
-    return { url, title, description };
+    return share(network);
   }
 
   copy() {

--- a/js/src/forum/components/ShareModal.js
+++ b/js/src/forum/components/ShareModal.js
@@ -3,10 +3,7 @@ import Modal from 'flarum/common/components/Modal';
 import Button from 'flarum/common/components/Button';
 import icon from 'flarum/common/helpers/icon';
 
-import pupa from 'pupa';
-import ItemList from 'flarum/common/utils/ItemList';
-import { canNativeShare } from '../util/share';
-import {getNetworkButton, getNetworkButtons} from '../util/networks';
+import { getNetworkButtons } from '../util/networks';
 
 export default class ShareModal extends Modal {
   oninit(vdom) {

--- a/js/src/forum/components/ShareModal.js
+++ b/js/src/forum/components/ShareModal.js
@@ -6,7 +6,7 @@ import icon from 'flarum/common/helpers/icon';
 import pupa from 'pupa';
 import ItemList from 'flarum/common/utils/ItemList';
 import { canNativeShare } from '../util/share';
-import { getNetworkButton } from '../util/networks';
+import {getNetworkButton, getNetworkButtons} from '../util/networks';
 
 export default class ShareModal extends Modal {
   oninit(vdom) {
@@ -35,14 +35,8 @@ export default class ShareModal extends Modal {
   }
 
   shareItems() {
-    const items = new ItemList();
+    const items = getNetworkButtons(this.discussion, true);
     const plainCopy = app.forum.attribute('fof-share-social.plain-copy');
-
-    {
-      this.networks
-        .filter((name) => name !== 'native' || canNativeShare(this.discussion))
-        .map((network) => items.add(`network-${network}`, getNetworkButton({ network, discussion: this.discussion, isRounded: true })));
-    }
 
     if (plainCopy) {
       items.add(

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -4,32 +4,78 @@ import DiscussionPage from 'flarum/forum/components/DiscussionPage';
 import Button from 'flarum/common/components/Button';
 import Model from 'flarum/common/Model';
 import Discussion from 'flarum/common/models/Discussion';
+import SplitDropdown from 'flarum/common/components/SplitDropdown';
 
 import ShareModal from './components/ShareModal';
+import { getNativeData } from './util/share';
+import { getNetworkButtons } from './util/networks';
+
+const getNetworks = () => {
+  let cache = null;
+
+  return (networks, def) => {
+    if (cache) return cache;
+
+    cache = [...networks];
+    const index = cache.indexOf(def);
+
+    if (index !== -1) {
+      cache.splice(index, 1);
+      cache.unshift(def);
+    }
+
+    return cache;
+  };
+};
 
 app.initializers.add('fof/share-social', () => {
   Discussion.prototype.shareUrl = Model.attribute('shareUrl');
 
   extend(DiscussionPage.prototype, 'sidebarItems', function (items) {
     const networks = app.forum.attribute('fof-share-social.networks');
+    const def = app.forum.attribute('fof-share-social.default');
 
-    if (!networks.length) return;
+    const isNativeShare = def === 'native';
+    const canNativeShare = isNativeShare && navigator.canShare?.(getNativeData(this.discussion));
 
-    items.add(
-      'share-social',
-      <Button
-        class="Button Button-icon Button--share"
-        icon="fas fa-share-alt"
-        onclick={() =>
-          app.modal.show(ShareModal, {
-            networks,
-            discussion: this.discussion,
-          })
-        }
-      >
-        {app.translator.trans('fof-share-social.forum.discussion.share_button')}
-      </Button>,
-      -1
-    );
+    if (def && (!isNativeShare || canNativeShare)) {
+      const list = getNetworkButtons(this.discussion);
+
+      // Use default share button text for native sharing
+      if (isNativeShare) {
+        list.get('native').children = app.translator.trans('fof-share-social.forum.discussion.share_button');
+      }
+
+      if (list.isEmpty()) return;
+
+      items.add(
+        'share-social',
+        <SplitDropdown
+          icon="fas fa-share-alt"
+          buttonClassName="Button--share"
+          accessibleToggleLabel={app.translator.trans('fof-share-social.forum.discussion.share_dropdown_accessible_label')}
+          lazyDraw={true}
+        >
+          {list.toArray()}
+        </SplitDropdown>
+      );
+    } else {
+      items.add(
+        'share-social',
+        <Button
+          class="Button Button-icon Button--share"
+          icon="fas fa-share-alt"
+          onclick={() =>
+            app.modal.show(ShareModal, {
+              networks,
+              discussion: this.discussion,
+            })
+          }
+        >
+          {app.translator.trans('fof-share-social.forum.discussion.share_button')}
+        </Button>,
+        -1
+      );
+    }
   });
 });

--- a/js/src/forum/util/networks.js
+++ b/js/src/forum/util/networks.js
@@ -1,0 +1,58 @@
+import app from 'flarum/forum/app';
+import ItemList from 'flarum/common/utils/ItemList';
+import Button from 'flarum/common/components/Button';
+import classList from 'flarum/common/utils/classList';
+import { data, networkIcons, networks } from './share';
+import pupa from 'pupa';
+
+export const getNetworkButton = ({ network, discussion, isRounded = false }) => {
+  return (
+    <Button
+      className={classList(`Button Button--block Share--${network}`, isRounded && 'Button--rounded')}
+      icon={`${networkIcons[network] || `fab fa-${network}`} fa-lg fa-fw`}
+      onclick={onNetworkButtonClick.bind(this, network, discussion)}
+    >
+      {app.translator.trans(`fof-share-social.lib.networks.${network}`)}
+    </Button>
+  );
+};
+
+export const onNetworkButtonClick = (network, discussion) => {
+  const payload = data(discussion);
+  const action = networks[network];
+
+  if (typeof action === 'function') {
+    return action(payload);
+  }
+
+  const width = 1000;
+  const height = 500;
+  const top = $(window).height() / 2 - height / 2;
+  const left = $(window).width() / 2 - width / 2;
+  const windowParams = `width=${width}, height= ${height}, top=${top}, left=${left}, status=no, scrollbars=no, resizable=no`;
+
+  for (const dataKey in payload) {
+    payload[dataKey] = encodeURIComponent(payload[dataKey]);
+  }
+
+  window.open(pupa(action, payload), app.title, windowParams);
+};
+
+export const getNetworkButtons = (discussion, isRounded) => {
+  const list = new ItemList();
+  const networks = app.forum.attribute('fof-share-social.networks');
+  const def = app.forum.attribute('fof-share-social.default');
+
+  for (const network of networks) {
+    // Do not add native share option if not supported
+    if (network === 'native' && !navigator.canShare?.(data(discussion))) continue;
+
+    list.add(network, getNetworkButton({ network, discussion, isRounded }));
+  }
+
+  if (list.has(def)) {
+    list.setPriority(def, 1000);
+  }
+
+  return list;
+};

--- a/js/src/forum/util/share.js
+++ b/js/src/forum/util/share.js
@@ -1,0 +1,41 @@
+import app from 'flarum/forum/app';
+import { getPlainContent, truncate } from 'flarum/common/utils/string';
+import pupa from 'pupa';
+
+export const networks = {
+  facebook: '//facebook.com/sharer/sharer.php?u={url}',
+  twitter: '//twitter.com/share?url={url}&text={title}',
+  linkedin: '//linkedin.com/shareArticle?mini=true&url={url}&title={title}&summary={description}',
+  reddit: '//www.reddit.com/submit?url={url}&title={title}',
+  whatsapp: '//api.whatsapp.com/send/?phone&text={title}%20{url}',
+  telegram: '//telegram.me/share/url?url={url}&text={title}',
+
+  vkontakte: '//vk.com/share.php?url={url}&title={title}&description={description}',
+  odnoklassniki: '//connect.ok.ru/offer?url={url}',
+  my_mail: '//connect.mail.ru/share?url={url}&title={title}&description={description}',
+  qq: '//connect.qq.com/widget/shareqq/iframe_index.html?url={url}&title={title}',
+  qzone: '//sns.qzone.qq.com/cgi-bin/qzshare/cgi_qzshare_onekey?url={url}&summary={description}&title={title}',
+
+  native: (data) => navigator.share(getNativeData(data)),
+};
+export const networkIcons = {
+  vkontakte: 'fab fa-vk',
+  my_mail: 'fas fa-at',
+  qq: 'fab fa-qq',
+  qzone: 'fas fa-star',
+  native: 'fas fa-share-square',
+};
+
+export const data = (discussion) => {
+  const url = discussion.shareUrl();
+  const title = app.title;
+  const description = (discussion.firstPost() && truncate(getPlainContent(discussion.firstPost()?.contentHtml()), 150, 0)) || '';
+
+  return { url, title, description };
+};
+
+export const getNativeData = ({ title, description, url }) => ({ title, text: description, url });
+
+export const canNativeShare = (discussion) => {
+  return navigator.canShare?.(getNativeData(discussion));
+};

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -16,7 +16,51 @@
     border-radius: @border-radius;
     margin-top: 10px !important;
   }
+}
 
+.item-share-social .Dropdown {
+  &:not(.itemCount1) {
+    .SplitDropdown-button {
+      width: unset;
+    }
+  }
+
+  .Dropdown-menu {
+    .Button {
+      width: 100% !important;
+      color: var(--button-color);
+      background: var(--button-bg);
+
+      .icon {
+        margin-top: 4px;
+      }
+
+      &:hover,
+      &:focus,
+      &.focus {
+        background-color: var(--button-bg-hover);
+      }
+
+      &:active,
+      &.active,
+      .open > .Dropdown-toggle& {
+        background-color: var(--button-bg-active);
+      }
+    }
+
+    @media @tablet-up {
+      padding: 0;
+
+      .Button {
+        margin: 4px 4px;
+        border-radius: @border-radius;
+        width: ~"calc(100% - 8px)" !important;
+      }
+    }
+  }
+}
+
+.item-share-social, .FofShareSocialModal {
   .Share--facebook {
     .Button--color(#fff, #3B5998);
   }

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -3,9 +3,14 @@ fof-share-social:
     settings:
       canonical-urls: Use canonical URLs for sharing
       plain-copy: Display plain URL copy
+      default-option: Default share option
+      default-option-help: |
+        Choosing a default option will convert the modal into a dropdown button.
+        If "Native Share" is selected, it will only be shown if the browser supports it, otherwise behavior reverts to original modal.
   forum:
     discussion:
       share_button: Share
+      share_dropdown_accessible_label: Toggle discussion share dropdown menu
 
     modal:
       title: Share


### PR DESCRIPTION
**Fixes #29**

**Changes proposed in this pull request:**
-  Add option for default share option
  -  Switches layout to `SplitDropdown` if share option is supported (i.e. if native is selected & supported)
  - I tried to use a custom component for `ShareButton` but `SplitDropdown` replaces the component class for the active one... so had to resort to using `<Button>` directly

**Reviewers should focus on:**
- If there's only one share option and it is made default, it'll just say the network's name, eg. Twitter, which I don't love. I'm not sure how to improve that though - adding more text like "Share with" is too long except in phone layout
- I made the dropdown buttons look separate like the modal to keep the style similar and differentiate from just selecting an option like the following dropdown

**Screenshot**
- Native & Twitter enabled, with native as default (Edge vs Firefox):
![image](https://github.com/FriendsOfFlarum/share-social/assets/6401250/aa65edca-8f80-4c9e-b3f5-2d3bcd829c5d)  ![image](https://github.com/FriendsOfFlarum/share-social/assets/6401250/48fa78e5-b8b7-4efb-8891-66e91fc7af57)
- With Twitter as default (Edge vs Firefox vs Phone):
![image](https://github.com/FriendsOfFlarum/share-social/assets/6401250/eb5834af-ec06-4ff0-9e28-399302941d74) ![image](https://github.com/FriendsOfFlarum/share-social/assets/6401250/4caedbe7-2f8a-457c-93bb-f598ef9407cf)
![image](https://github.com/FriendsOfFlarum/share-social/assets/6401250/c9d42c8a-169a-4dbd-9501-abfd39edea8c)
- Native default w/ more alternative options 
![image](https://github.com/FriendsOfFlarum/share-social/assets/6401250/d1444c2b-3391-481c-81a4-47cdd32e9f83)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~
