### PR TITLE
feat: conditional X icon and brand colour via blomstra/fontawesome

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -10,3 +10,4 @@ jobs:
       enable_phpstan: true
 
       backend_directory: .
+      php_versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]'

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ composer require fof/share-social
 composer update fof/share-social
 ```
 
+### X (Twitter) icon
+
+By default, the X/Twitter button uses the classic Twitter bird icon (Font Awesome 5, which Flarum ships with) and the Twitter blue colour.
+
+To get the proper X logo and black brand colour, install [blomstra/fontawesome](https://discuss.flarum.org/d/31219-blomstra-font-awesome-6) and configure it with a Font Awesome **6.5.2 or later** kit. The `x-twitter` icon was introduced in FA 6.5.2 — older kit versions will show a blank icon.
+
+```sh
+composer require blomstra/fontawesome
+```
+
 ### Links
 
 - [Packagist](https://packagist.org/packages/fof/share-social)

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
     "require": {
         "flarum/core": "^1.8.0"
     },
+    "suggest": {
+        "blomstra/fontawesome": "Enables Font Awesome 6, which includes the X (Twitter) icon"
+    },
     "replace": {
         "avatar4eg/flarum-ext-share-social": "*"
     },
@@ -46,9 +49,9 @@
                 "color": "#fff"
             }
         },
-        "flagrow": {
-            "discuss": "https://discuss.flarum.org/d/20401"
-        },
+        "optional-dependencies": [
+            "blomstra/fontawesome"
+        ],
         "flarum-cli": {
             "modules": {
                 "githubActions": true
@@ -56,7 +59,8 @@
         }
     },
     "require-dev": {
-        "flarum/phpstan": "*"
+        "flarum/phpstan": "*",
+        "blomstra/fontawesome": "*"
     },
     "scripts": {
         "analyse:phpstan": "phpstan analyse",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         }
     ],
     "require": {
+        "php": "^7.4 || ^8.0",
         "flarum/core": "^1.8.0"
     },
     "suggest": {

--- a/extend.php
+++ b/extend.php
@@ -36,4 +36,17 @@ return [
 
     (new Extend\ApiSerializer(DiscussionSerializer::class))
         ->attributes(DiscussionAttributes::class),
+
+    (new Extend\Conditional())
+        ->whenExtensionEnabled('blomstra-fontawesome', fn() => [
+            (new Extend\ApiSerializer(ForumSerializer::class))
+                ->attribute('fof-share-social.fa6Enabled', true),
+
+            (new Extend\Theme())
+                ->addCustomLessVariable('fof-share-social--twitter-color', fn() => '#000000'),
+        ])
+        ->whenExtensionDisabled('blomstra-fontawesome', fn() => [
+            (new Extend\Theme())
+                ->addCustomLessVariable('fof-share-social--twitter-color', fn() => '#00ACED'),
+        ])
 ];

--- a/extend.php
+++ b/extend.php
@@ -40,7 +40,7 @@ return [
     (new Extend\Conditional())
         ->whenExtensionEnabled('blomstra-fontawesome', fn () => [
             (new Extend\ApiSerializer(ForumSerializer::class))
-                ->attribute('fof-share-social.fa6Enabled', fn() => true),
+                ->attribute('fof-share-social.fa6Enabled', fn () => true),
 
             (new Extend\Theme())
                 ->addCustomLessVariable('fof-share-social--twitter-color', fn () => '#000000'),

--- a/extend.php
+++ b/extend.php
@@ -40,7 +40,7 @@ return [
     (new Extend\Conditional())
         ->whenExtensionEnabled('blomstra-fontawesome', fn () => [
             (new Extend\ApiSerializer(ForumSerializer::class))
-                ->attribute('fof-share-social.fa6Enabled', true),
+                ->attribute('fof-share-social.fa6Enabled', fn() => true),
 
             (new Extend\Theme())
                 ->addCustomLessVariable('fof-share-social--twitter-color', fn () => '#000000'),

--- a/extend.php
+++ b/extend.php
@@ -38,15 +38,15 @@ return [
         ->attributes(DiscussionAttributes::class),
 
     (new Extend\Conditional())
-        ->whenExtensionEnabled('blomstra-fontawesome', fn() => [
+        ->whenExtensionEnabled('blomstra-fontawesome', fn () => [
             (new Extend\ApiSerializer(ForumSerializer::class))
                 ->attribute('fof-share-social.fa6Enabled', true),
 
             (new Extend\Theme())
-                ->addCustomLessVariable('fof-share-social--twitter-color', fn() => '#000000'),
+                ->addCustomLessVariable('fof-share-social--twitter-color', fn () => '#000000'),
         ])
-        ->whenExtensionDisabled('blomstra-fontawesome', fn() => [
+        ->whenExtensionDisabled('blomstra-fontawesome', fn () => [
             (new Extend\Theme())
-                ->addCustomLessVariable('fof-share-social--twitter-color', fn() => '#00ACED'),
-        ])
+                ->addCustomLessVariable('fof-share-social--twitter-color', fn () => '#00ACED'),
+        ]),
 ];

--- a/js/src/forum/util/networks.tsx
+++ b/js/src/forum/util/networks.tsx
@@ -2,7 +2,7 @@ import app from 'flarum/forum/app';
 import ItemList from 'flarum/common/utils/ItemList';
 import Button from 'flarum/common/components/Button';
 import classList from 'flarum/common/utils/classList';
-import { data, networkIcons, networks, ShareableDiscussion } from './share';
+import { data, getNetworkIcon, networks, ShareableDiscussion } from './share';
 import pupa from 'pupa';
 import Mithril from 'mithril';
 
@@ -18,7 +18,7 @@ export const getNetworkButton = ({
   return (
     <Button
       className={classList(`Button Button--block Share--${network}`, isRounded && 'Button--rounded')}
-      icon={`${networkIcons[network] || `fab fa-${network}`} fa-lg fa-fw`}
+      icon={`${getNetworkIcon(network)} fa-lg fa-fw`}
       onclick={onNetworkButtonClick.bind(null, network, discussion)}
     >
       {app.translator.trans(`fof-share-social.lib.networks.${network}`)}

--- a/js/src/forum/util/share.ts
+++ b/js/src/forum/util/share.ts
@@ -1,3 +1,4 @@
+import app from 'flarum/forum/app';
 import { getPlainContent, truncate } from 'flarum/common/utils/string';
 import Discussion from 'flarum/common/models/Discussion';
 
@@ -32,6 +33,16 @@ export const networkIcons: Record<string, string> = {
   qq: 'fab fa-qq',
   qzone: 'fas fa-star',
   native: 'fas fa-share-square',
+};
+
+const networkIconsFA6: Record<string, string> = {
+  twitter: 'fab fa-x-twitter',
+};
+
+export const getNetworkIcon = (network: string): string => {
+  const fa6 = app.forum.attribute('fof-share-social.fa6Enabled') as boolean | undefined;
+  const icons = fa6 ? { ...networkIcons, ...networkIconsFA6 } : networkIcons;
+  return icons[network] || `fab fa-${network}`;
 };
 
 export type ShareableDiscussion = Discussion & { shareUrl: () => string };

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -70,7 +70,7 @@
   }
 
   .Share--twitter {
-    .Button--color(#fff, #00ACED);
+    .Button--color(#fff, @fof-share-social--twitter-color);
   }
 
   .Share--reddit {


### PR DESCRIPTION
## Summary

Adds conditional support for the X (Twitter) brand icon and colour when [`blomstra/fontawesome`](https://discuss.flarum.org/d/31219-blomstra-font-awesome-6) is enabled:

- **Icon**: uses `fa-brands fa-x-twitter` (FA 6.5.2+) instead of the FA5 bird (`fab fa-twitter`)
- **Colour**: switches to X brand black (`#000000`) via the `@fof-share-social--twitter-color` LESS variable; falls back to Twitter blue (`#00ACED`) when FA6 is not present

### Implementation

- `extend.php` — `Extend\Conditional` with `whenExtensionEnabled`/`whenExtensionDisabled` on `blomstra-fontawesome` registers the appropriate LESS variable and the `fof-share-social.fa6Enabled` forum attribute
- `js/src/forum/util/share.ts` — new `getNetworkIcon()` reads `fa6Enabled` at runtime and merges FA6 icon overrides
- `resources/less/forum.less` — `.Share--twitter` colour uses `@fof-share-social--twitter-color`
- `composer.json` — adds `suggest` entry for `blomstra/fontawesome`; sets minimum PHP to `^7.4 || ^8.0` (arrow functions require 7.4+)
- `.github/workflows/backend.yml` — CI matrix updated to test PHP 7.4–8.5
- `README.md` — documents the X icon feature and the FA kit ≥ 6.5.2 requirement

> **Note:** the `x-twitter` icon was introduced in Font Awesome 6.5.2. Older kit versions will display a blank icon.

## Test plan

- [ ] With `blomstra/fontawesome` **disabled**: Twitter button shows bird icon, Twitter blue background
- [ ] With `blomstra/fontawesome` **enabled** (FA kit ≥ 6.5.2): Twitter button shows X icon, black background
- [ ] With `blomstra/fontawesome` **enabled** (FA kit < 6.5.2): Twitter button shows blank icon (expected — documented in README)
- [ ] PHPStan passes on PHP 7.4+
- [ ] No visual regression on other network buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)