### PR TITLE
[1.x] fix: keep SplitDropdown buttons on one line on mobile

### DIFF
--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -18,6 +18,19 @@
   }
 }
 
+.item-share-social {
+  // Keep the ButtonGroup's main + toggle buttons on one line on mobile
+  @media @phone {
+    .ButtonGroup {
+      display: inline-flex;
+
+      > .Button {
+        float: none;
+      }
+    }
+  }
+}
+
 .item-share-social .Dropdown {
   &:not(.itemCount1) {
     .SplitDropdown-button {


### PR DESCRIPTION
## Summary

On `@phone`, sidebar items are `display: inline-block` and `.ButtonGroup` uses `float: left` children with no width constraint on the container. This causes the dropdown toggle arrow to wrap below the main share button.

Fix: switch `.item-share-social .ButtonGroup` to `display: inline-flex` on mobile, which keeps the main button and toggle arrow on one line.

## Test plan

- [ ] On mobile viewport: share button and dropdown arrow sit side-by-side on one line
- [ ] On tablet/desktop: no visual regression (rule is scoped to `@phone` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)